### PR TITLE
Motor Initialization Command Sequence Creation

### DIFF
--- a/2025-ReefScape/src/main/java/frc/robot/Constants.java
+++ b/2025-ReefScape/src/main/java/frc/robot/Constants.java
@@ -443,9 +443,9 @@ public final class Constants {
       public static double kDriveKff = NTDouble.create(.17,"SwerveModule/kDriveKff",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKFF(val)));
       
       // Control Loop Gains - Steering
-      public static double kSteerKp  = NTDouble.create(0.3,"SwerveModule/kSteerKp",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKP(val)));
-      public static double kSteerKi  = NTDouble.create(0, "SwerveModule/kSteerKi",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKI(val)));
-      public static double kSteerKd  = NTDouble.create(0,"SwerveModule/kSteerKd",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKD(val)));     
+      public static double kSteerKp  = NTDouble.create(0.3,"SwerveModule/kSteerKp",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKP(val)));
+      public static double kSteerKi  = NTDouble.create(0, "SwerveModule/kSteerKi",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKI(val)));
+      public static double kSteerKd  = NTDouble.create(0,"SwerveModule/kSteerKd",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKD(val)));     
       public static double kSteerKff = 0;
     }
 

--- a/2025-ReefScape/src/main/java/frc/robot/Constants.java
+++ b/2025-ReefScape/src/main/java/frc/robot/Constants.java
@@ -440,10 +440,10 @@ public final class Constants {
       public static double kDriveKp  = NTDouble.create(.3,"SwerveModule/kDriveKp",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKP(val)));
       public static double kDriveKi  = NTDouble.create(.0, "SwerveModule/kDriveKi",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKI(val)));
       public static double kDriveKd  = NTDouble.create(.0,"SwerveModule/kDriveKd",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKD(val)));
-      public static double kDriveKff = NTDouble.create(.17,"SwerveModule/kDriveKff",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKFF(val)));
+      public static double kDriveKff = NTDouble.create(.12,"SwerveModule/kDriveKff",val->DriveTrain.forEachSwerveModule((m)->m.m_motorDrive.withKFF(val)));
       
       // Control Loop Gains - Steering
-      public static double kSteerKp  = NTDouble.create(0.3,"SwerveModule/kSteerKp",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKP(val)));
+      public static double kSteerKp  = NTDouble.create(1.0,"SwerveModule/kSteerKp",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKP(val)));
       public static double kSteerKi  = NTDouble.create(0, "SwerveModule/kSteerKi",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKI(val)));
       public static double kSteerKd  = NTDouble.create(0,"SwerveModule/kSteerKd",val->DriveTrain.forEachSwerveModule((m)->m.m_motorSteer.withKD(val)));     
       public static double kSteerKff = 0;

--- a/2025-ReefScape/src/main/java/frc/utils/Motor.java
+++ b/2025-ReefScape/src/main/java/frc/utils/Motor.java
@@ -62,15 +62,16 @@ public class Motor {
     nt_angleinit,
     nt_speedcmd;
 
-    public Command krakenSetup(){
-        return Commands.sequence( 
-                    Commands.waitUntil(() -> motor_talon.getConfigurator().apply(config_talon).isOK()),
-                    new InstantCommand(()-> m_setupMotorDone = true)
-                    );
-    }
-    public Command neoSetup(){
-        return Commands.sequence(
-                    new InstantCommand(() -> motor_neo.disable()),
+    public void scheduleSetup(){
+        switch (motorType){
+            case KRAKEN:
+                m_setupMotor = Commands.sequence( 
+                            Commands.waitUntil(() -> motor_talon.getConfigurator().apply(config_talon).isOK()),
+                            new InstantCommand(()-> m_setupMotorDone = true)
+                            );
+                break;
+            case NEO:
+                m_setupMotor = Commands.sequence(
                     Commands.waitUntil(() -> (encoder_neo = motor_neo.getEncoder()) != null),
                     Commands.waitUntil(() -> {var status = motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters); return status == REVLibError.kOk || status == REVLibError.kCannotPersistParametersWhileEnabled;}),
                     Commands.waitUntil(() -> {
@@ -81,8 +82,16 @@ public class Motor {
                         return true;
                     }),
                     new InstantCommand(()-> {m_setupMotorDone = true; m_calibrated = true;})
-                ); 
+                );
+                break;
+            default:
+                m_setupMotor = Commands.sequence();
+        }
+        m_setupMotorDone = false;
+        m_setupMotor.ignoringDisable(true).schedule();
+        m_setupScheduled = true;
     }
+
     public Motor (int CANID_, MyMotorType motorType_, String name_) {
         CANID = CANID_;
         motorType = motorType_;
@@ -96,40 +105,18 @@ public class Motor {
             case KRAKEN:
                 motor_talon = new TalonFX(CANID);
                 config_talon = new TalonFXConfiguration();
-                m_setupMotor = krakenSetup();
                 break;
             case NEO:
                 motor_neo = new MyCANSparkMax(CANID, MotorType.kBrushless);
                 controller_neo = motor_neo.getClosedLoopController();
                 encoder_neo = motor_neo.getEncoder();
-                config_neo = new SparkMaxConfig();
-                motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters); 
-                
-                m_setupMotor = neoSetup();
-                
+                config_neo = new SparkMaxConfig();             
                 break;
         }
     }
 
     public enum MyMotorType {
         KRAKEN, NEO
-    }
-
-    private void repeatSetup(){
-        switch (motorType){
-            case KRAKEN:
-                m_setupMotor = krakenSetup();
-                break;
-            case NEO:
-                m_setupMotor = neoSetup();
-                break;
-        }
-        // Used for rescheduling the motor configuration when parameters change after setup via the Motor class methods.
-        if (m_setupMotorDone){
-            m_setupMotorDone = false;
-            m_setupMotor.ignoringDisable(true).schedule();
-            m_setupScheduled = true;
-        }
     }
 
     public Motor inverted(boolean invert){
@@ -144,7 +131,7 @@ public class Motor {
                 config_neo.inverted(invert);       
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
 
@@ -158,7 +145,7 @@ public class Motor {
                 config_neo.idleMode(idleMode);       
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -172,7 +159,7 @@ public class Motor {
                 config_neo.encoder.positionConversionFactor(_positionFactor);       
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
     public Motor velocityConversionFactor(double _velocityFactor){
@@ -185,7 +172,7 @@ public class Motor {
                 config_neo.encoder.velocityConversionFactor(_velocityFactor);       
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -198,13 +185,13 @@ public class Motor {
                 config_neo.smartCurrentLimit((int)stallLimit);       
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
     public Motor setCalibration(double calibrate){
         calibration = calibrate;
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
 
@@ -217,6 +204,7 @@ public class Motor {
                 config_neo.closedLoop.feedbackSensor(sensor);     
                 break;
         }
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -229,7 +217,7 @@ public class Motor {
             case NEO:
                 config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
 
@@ -242,7 +230,7 @@ public class Motor {
             case NEO:
                 config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
     public Motor withKD(double val){
@@ -254,7 +242,7 @@ public class Motor {
             case NEO:
                 config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
 
@@ -267,7 +255,7 @@ public class Motor {
             case NEO:
                 config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }
 
@@ -287,7 +275,7 @@ public class Motor {
                 config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0);    
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -300,7 +288,7 @@ public class Motor {
                 config_neo.closedLoop.outputRange(rangeMin, rangeMax);     
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -313,7 +301,7 @@ public class Motor {
                 config_neo.closedLoop.iZone(zone);    
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -326,7 +314,7 @@ public class Motor {
                 config_neo.closedLoop.positionWrappingEnabled(enabled);    
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     } 
 
@@ -341,7 +329,7 @@ public class Motor {
                     .positionWrappingMaxInput(max);  
                 break;
         }
-        repeatSetup();
+        if (m_setupMotorDone) scheduleSetup();
         return this;
     }     
 
@@ -409,9 +397,9 @@ public class Motor {
     }
 
     public boolean isSetupDone() {
-        if (m_setupScheduled == false && m_setupMotor != null) {
-            m_setupMotor.ignoringDisable(true).schedule();
-            m_setupScheduled = true;
+        
+        if (m_setupScheduled == false && m_setupMotorDone == false) {
+            scheduleSetup();
         }
         return m_setupMotorDone;
     }

--- a/2025-ReefScape/src/main/java/frc/utils/Motor.java
+++ b/2025-ReefScape/src/main/java/frc/utils/Motor.java
@@ -8,6 +8,7 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
+import com.revrobotics.spark.ClosedLoopSlot;
 import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkClosedLoopController;
@@ -69,8 +70,9 @@ public class Motor {
     }
     public Command neoSetup(){
         return Commands.sequence(
+                    new InstantCommand(() -> motor_neo.disable()),
                     Commands.waitUntil(() -> (encoder_neo = motor_neo.getEncoder()) != null),
-                    Commands.waitUntil(() -> (motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters)) == REVLibError.kOk),
+                    Commands.waitUntil(() -> {var status = motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters); return status == REVLibError.kOk || status == REVLibError.kCannotPersistParametersWhileEnabled;}),
                     Commands.waitUntil(() -> {
                         if(!m_calibrated){
                             nt_angleinit.set(calibration);
@@ -225,7 +227,7 @@ public class Motor {
                 config_talon.Slot0.withKP(m_Kp_0);
                 break;
             case NEO:
-                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0);
+                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
         repeatSetup();
         return this;
@@ -238,7 +240,7 @@ public class Motor {
                 config_talon.Slot0.withKI(m_Ki_0);
                 break;
             case NEO:
-                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0);
+                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
         repeatSetup();
         return this;
@@ -250,7 +252,7 @@ public class Motor {
                 config_talon.Slot0.withKD(m_Kd_0);
                 break;
             case NEO:
-                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0);
+                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
         repeatSetup();
         return this;
@@ -263,7 +265,7 @@ public class Motor {
                 config_talon.Slot0.withKV(m_Kff_0);
                 break;
             case NEO:
-                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0);
+                config_neo.closedLoop.pidf(m_Kp_0,m_Ki_0,m_Kd_0,m_Kff_0,ClosedLoopSlot.kSlot0);
         }
         repeatSetup();
         return this;

--- a/2025-ReefScape/src/main/java/frc/utils/Motor.java
+++ b/2025-ReefScape/src/main/java/frc/utils/Motor.java
@@ -61,6 +61,26 @@ public class Motor {
     nt_angleinit,
     nt_speedcmd;
 
+    public Command krakenSetup(){
+        return Commands.sequence( 
+                    Commands.waitUntil(() -> motor_talon.getConfigurator().apply(config_talon).isOK()),
+                    new InstantCommand(()-> m_setupMotorDone = true)
+                    );
+    }
+    public Command neoSetup(){
+        return Commands.sequence(
+                    Commands.waitUntil(() -> (encoder_neo = motor_neo.getEncoder()) != null),
+                    Commands.waitUntil(() -> (motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters)) == REVLibError.kOk),
+                    Commands.waitUntil(() -> {
+                        if(!m_calibrated){
+                            nt_angleinit.set(calibration);
+                            return encoder_neo.setPosition((calibration)/4096.0 * (2*Math.PI)) == REVLibError.kOk;
+                        }
+                        return true;
+                    }),
+                    new InstantCommand(()-> {m_setupMotorDone = true; m_calibrated = true;})
+                ); 
+    }
     public Motor (int CANID_, MyMotorType motorType_, String name_) {
         CANID = CANID_;
         motorType = motorType_;
@@ -74,10 +94,7 @@ public class Motor {
             case KRAKEN:
                 motor_talon = new TalonFX(CANID);
                 config_talon = new TalonFXConfiguration();
-                m_setupMotor = Commands.sequence( 
-                    Commands.waitUntil(() -> motor_talon.getConfigurator().apply(config_talon).isOK()),
-                    new InstantCommand(()-> m_setupMotorDone = true)
-                    ); 
+                m_setupMotor = krakenSetup();
                 break;
             case NEO:
                 motor_neo = new MyCANSparkMax(CANID, MotorType.kBrushless);
@@ -86,18 +103,7 @@ public class Motor {
                 config_neo = new SparkMaxConfig();
                 motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters); 
                 
-                m_setupMotor = Commands.sequence(
-                    Commands.waitUntil(() -> (encoder_neo = motor_neo.getEncoder()) != null),
-                    Commands.waitUntil(() -> (motor_neo.configure(config_neo, ResetMode.kResetSafeParameters, PersistMode.kPersistParameters)) == REVLibError.kOk),
-                    Commands.waitUntil(() -> {
-                        if(!m_calibrated){
-                            nt_angleinit.set(calibration);
-                            return encoder_neo.setPosition((calibration)/4096.0 * (2*Math.PI)) == REVLibError.kOk;
-                        }
-                        return true;
-                    }),
-                    new InstantCommand(()-> {m_setupMotorDone = true; m_calibrated = true;})
-                ); 
+                m_setupMotor = neoSetup();
                 
                 break;
         }
@@ -108,6 +114,14 @@ public class Motor {
     }
 
     private void repeatSetup(){
+        switch (motorType){
+            case KRAKEN:
+                m_setupMotor = krakenSetup();
+                break;
+            case NEO:
+                m_setupMotor = neoSetup();
+                break;
+        }
         // Used for rescheduling the motor configuration when parameters change after setup via the Motor class methods.
         if (m_setupMotorDone){
             m_setupMotorDone = false;


### PR DESCRIPTION
In order to push across a new motor configuration, the intialization commands need to run again. In order to prevent an exception from occuring, we need to create a new command sequence each time. The CommandScheduler seems to delete a command sequence once it is finished leading to undefined behavior if we try scheduling it again. Created a new function for scheduling the setup sequence which creates a new CommandSequence each time it is called.