### PR TITLE
Algae Tip Prevention

### DIFF
--- a/2025-ReefScape/src/main/java/frc/robot/Constants.java
+++ b/2025-ReefScape/src/main/java/frc/robot/Constants.java
@@ -260,6 +260,8 @@ public final class Constants {
 
   public static class GyroConstants{
     public static boolean kEnabled = true;
+    public static double kTippingAngle = Units.degreesToRadians(NTDouble.create(12.5,"Gyro/kTippingAngle",val->kTippingAngle=Units.degreesToRadians(val)));
+    public static double kTippingHysteresis = Units.degreesToRadians(NTDouble.create(5,"Gyro/kTippingHysteresis",val->kTippingHysteresis=Units.degreesToRadians(val)));
     public static int kCANID = 50;
     public static double kVisionCorrectionMaxRate = Units.degreesToRadians(NTDouble.create(40,"Gyro/kVisionCorrectionMaxRate",val->kVisionCorrectionMaxRate=Units.degreesToRadians(val)));
   }

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Arm.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Arm.java
@@ -48,7 +48,7 @@ public class Arm extends SubsystemBase{
     boolean scoringLevels2or3 = false;
     boolean scoringLevel4 = false;
 
-    Action m_tipProtect = new Action(false).onTrue(()->{moveToLevel(ScoreLevel.TROUGH); Controller.getAccessoryInstance().m_directArm=false;});
+    Action m_tipProtect = new Action(false).onTrue(()->{Controller.getAccessoryInstance().m_directArm=false; moveToLevel(ScoreLevel.FUNNEL);});
     
     DoublePublisher
         nt_positionSensor,

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Arm.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Arm.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.ArmConstants;
+import frc.utils.Action;
 import frc.utils.Calibrate;
 import frc.utils.CalibrationMap;
 import frc.utils.Motor;
@@ -47,6 +48,8 @@ public class Arm extends SubsystemBase{
     boolean scoringLevels2or3 = false;
     boolean scoringLevel4 = false;
 
+    Action m_tipProtect = new Action(false).onTrue(()->{moveToLevel(ScoreLevel.TROUGH); Controller.getAccessoryInstance().m_directArm=false;});
+    
     DoublePublisher
         nt_positionSensor,
         nt_safetyLimit,
@@ -175,6 +178,8 @@ public class Arm extends SubsystemBase{
             m_angleSensorSim.set(m_angleSensorSimMap.get(m_angleTarget));
         }
 
+        
+        m_tipProtect.calculate(Gyro.getInstance().isTipping());
         setArmAngleSafely(m_angleTarget);
 
         nt_setupDone.set(m_setupDone);

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/DriveTrain.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/DriveTrain.java
@@ -70,6 +70,8 @@ public class DriveTrain extends SubsystemBase {
     m_maxRotate = maxRotateRadiansPerSecond;
   }
 
+  public boolean m_tippingRecovery = false;
+
   // Create new swerve modules
   public SwerveModule frontLeft = new SwerveModule(kDriveTrain.kSwerveModule.kCANID_FrontLeft, kDriveTrain.kSwerveModule.kCalibrationFrontLeft, "frontLeft");
   public SwerveModule frontRight = new SwerveModule(kDriveTrain.kSwerveModule.kCANID_FrontRight, kDriveTrain.kSwerveModule.kCalibrationFrontRight, "frontRight");
@@ -317,7 +319,14 @@ public class DriveTrain extends SubsystemBase {
       m_targetHeading = m_currentHeading;
     }
 
-    RunDrive();
+    // If robot is tipping, align the swerve modules in the direction of the tip only let the motors drive away from the obstacle.
+    if (Gyro.getInstance().isTipping()){
+      double speed = VectorUtils.SRSS(FlightStick.forward, FlightStick.left)*m_maxSpeed;
+      SwerveModuleState state = new SwerveModuleState(speed,new Rotation2d(Gyro.getInstance().getTippingAngle()));
+      forEachSwerveModule((m)->{m.setState(state);});
+    } else {
+      RunDrive();
+    }
   }
 
   public static void forEachSwerveModule(Consumer<SwerveModule> lambda){

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Elevator.java
@@ -35,7 +35,7 @@ public class Elevator extends SubsystemBase {
         return instance;
     }
 
-    Action m_tipProtect = new Action(false).onTrue(()->{moveToLevel(ScoreLevel.TROUGH); Controller.getAccessoryInstance().m_directElevator=false;});
+    Action m_tipProtect = new Action(false).onTrue(()->{Controller.getAccessoryInstance().m_directElevator=false; moveToLevel(ScoreLevel.FUNNEL);});
 
     public Motor m_EleMotor;
     boolean setupElevator = false;

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Elevator.java
@@ -17,6 +17,7 @@ import frc.robot.Robot;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.Constants.ScoreConstants;
 import frc.robot.Constants.ScoreConstants.ScoreLevel;
+import frc.utils.Action;
 import frc.utils.Motor;
 import frc.utils.Motor.GainSlot;
 import frc.utils.NTValues.NTBoolean;
@@ -33,6 +34,8 @@ public class Elevator extends SubsystemBase {
     public static Elevator getInstance(){
         return instance;
     }
+
+    Action m_tipProtect = new Action(false).onTrue(()->{moveToLevel(ScoreLevel.TROUGH); Controller.getAccessoryInstance().m_directElevator=false;});
 
     public Motor m_EleMotor;
     boolean setupElevator = false;
@@ -187,6 +190,8 @@ public class Elevator extends SubsystemBase {
             m_targetHeight = getPosition();
         }
 
+        m_tipProtect.calculate(Gyro.getInstance().isTipping());
+        
         // Start calibration sequence
         if (DriverStation.isEnabled()){
             if (Robot.isReal() && !m_isCalibrated.get() && m_isCalibrating.get()==0){

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/FlightStick.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/FlightStick.java
@@ -134,6 +134,8 @@ public class FlightStick extends Joystick {
       Btm11Btn.onFalse(new InstantCommand(() -> {
         DriveTrain.getInstance().setMaxRotate(DriveConstants.kMaxRotationVelocity[m_speedSelector]);
       }));
+      Btm12Btn.onTrue(new InstantCommand(()->Gyro.getInstance().m_enableTipDetection = false));
+      Btm12Btn.onFalse(new InstantCommand(()->Gyro.getInstance().m_enableTipDetection = true));
 
 
       /* Intake in */

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Gyro.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Gyro.java
@@ -69,6 +69,11 @@ public class Gyro extends SubsystemBase {
   final DoublePublisher nt_roll = table.getDoubleTopic("roll").publish();
   final DoublePublisher nt_offset = table.getDoubleTopic("offset").publish();
   final BooleanPublisher nt_status = table.getBooleanTopic("status").publish();
+  final BooleanPublisher nt_isTipped = table.getBooleanTopic("isTipped").publish();
+  final DoublePublisher nt_tipHeading = table.getDoubleTopic("tipHeading").publish();
+  final DoublePublisher nt_gvx = table.getDoubleTopic("gvx").publish();
+  final DoublePublisher nt_gvy = table.getDoubleTopic("gvy").publish();
+  final DoublePublisher nt_gvz = table.getDoubleTopic("gvz").publish();
 
   final NTDouble nt_simOffset = new NTDouble(0.0,table,"CAUTION/offset",val->initypr[0]=initypr[0]+val); {nt_simOffset.resetOnRecv=true;}
   final DoublePublisher nt_simYaw = table.getDoubleTopic("sim/yaw").publish();
@@ -109,8 +114,8 @@ public class Gyro extends SubsystemBase {
     
     // Get new ypr values in degrees
     double [] newypr = getypr();
-
-    m_isTipped.calculate(m_enableTipDetection ? VectorUtils.SRSS(getPitch(),getRoll()) : 0);
+    getTippingAngle();
+    m_isTipped.calculate(m_enableTipDetection ? VectorUtils.SRSS(VectorUtils.angleDifference(0,getPitch()),VectorUtils.angleDifference(0,getRoll())) : 0);
 
     // Convert the continuous values offset by the init or vision correction to radians, this outputs values between 0 and 2*pi
     ypr[0] = (((newypr[0]+initypr[0]) % 360)*(Math.PI)/180.0 + 2*Math.PI) % (2*Math.PI);
@@ -122,6 +127,7 @@ public class Gyro extends SubsystemBase {
       initypr[0] += 180.0/Math.PI * Math.max(Math.min(VectorUtils.angleDifference(PoseEstimator.getInstance().m_visionTheta.getRadians(),ypr[0]), GyroConstants.kVisionCorrectionMaxRate * 0.020), -GyroConstants.kVisionCorrectionMaxRate * 0.020);
     }
 
+    nt_isTipped.set(m_isTipped.get());
     nt_status.set(getStatus());
     nt_yaw.set(Units.radiansToDegrees(ypr[0]));
     nt_pitch.set(Units.radiansToDegrees(ypr[1]));
@@ -141,8 +147,8 @@ public class Gyro extends SubsystemBase {
       simstate.addYaw(Units.radiansToDegrees(VectorUtils.angleDifference(simyawrad,lastSimYawRad)));
     }
     double yaw = (pidgey.getYaw().getValueAsDouble() % 360 + 360) % 360;
-    double pitch = pidgey.getPitch().getValueAsDouble();
-    double roll = pidgey.getRoll().getValueAsDouble(); 
+    double pitch = pidgey.getRoll().getValueAsDouble();
+    double roll = pidgey.getPitch().getValueAsDouble(); 
 
     return new double[]{yaw, pitch, roll};
   }
@@ -165,12 +171,16 @@ public class Gyro extends SubsystemBase {
    * @return angle from forward in radians
    */
   public double getTippingAngle(){
-    double gvx = pidgey.getGravityVectorX().getValueAsDouble();
-    double gvy = pidgey.getGravityVectorY().getValueAsDouble();
-    if (gvx <= 1e-6 && gvy <= 1e-6){
+    double gvx = -pidgey.getGravityVectorY().getValueAsDouble();
+    double gvy = pidgey.getGravityVectorX().getValueAsDouble();
+    nt_gvx.set(gvx);
+    nt_gvy.set(gvy);
+    if (Math.abs(gvx) <= 1e-6 && Math.abs(gvy) <= 1e-6){
       return 0;
     }
-    return new Translation2d(gvx,gvy).getAngle().getRadians();
+    double tipHeading = new Translation2d(gvx,gvy).getAngle().getRadians();
+    nt_tipHeading.set(Units.radiansToDegrees(tipHeading));
+    return tipHeading;
   }
 
   public void resetPrimarySensor() {

--- a/2025-ReefScape/src/main/java/frc/robot/subsystems/Gyro.java
+++ b/2025-ReefScape/src/main/java/frc/robot/subsystems/Gyro.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
 import frc.robot.Constants.GyroConstants;
+import frc.utils.Hysteresis;
 import frc.utils.VectorUtils;
 import frc.utils.NTValues.NTBoolean;
 import frc.utils.NTValues.NTDouble;
@@ -16,6 +17,7 @@ import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.hardware.Pigeon2;
 import com.ctre.phoenix6.sim.Pigeon2SimState;
 
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
@@ -30,7 +32,9 @@ public class Gyro extends SubsystemBase {
   private static Pigeon2 pidgey = new Pigeon2(GyroConstants.kCANID, "rio");
   private static Pigeon2SimState simstate = new Pigeon2SimState(pidgey);
 
-  private static Gyro gyro = new Gyro(); 
+  public boolean m_enableTipDetection = true;
+
+  private static Gyro gyro = new Gyro();
   
   public static Gyro getInstance(){
     return gyro;
@@ -57,6 +61,8 @@ public class Gyro extends SubsystemBase {
   
   public boolean init = true;
   NTBoolean nt_init = new NTBoolean(false,table,"init",val->init=val); {nt_init.resetOnRecv = true;}
+
+  Hysteresis m_isTipped = new Hysteresis().withThreshold(GyroConstants.kTippingAngle).withHysteresis(GyroConstants.kTippingHysteresis);
 
   final DoublePublisher nt_yaw = table.getDoubleTopic("yaw").publish();
   final DoublePublisher nt_pitch = table.getDoubleTopic("pitch").publish();
@@ -104,6 +110,8 @@ public class Gyro extends SubsystemBase {
     // Get new ypr values in degrees
     double [] newypr = getypr();
 
+    m_isTipped.calculate(m_enableTipDetection ? VectorUtils.SRSS(getPitch(),getRoll()) : 0);
+
     // Convert the continuous values offset by the init or vision correction to radians, this outputs values between 0 and 2*pi
     ypr[0] = (((newypr[0]+initypr[0]) % 360)*(Math.PI)/180.0 + 2*Math.PI) % (2*Math.PI);
     ypr[1] = (((newypr[1]+initypr[1]) % 360)*(Math.PI)/180.0 + 2*Math.PI) % (2*Math.PI);
@@ -133,11 +141,8 @@ public class Gyro extends SubsystemBase {
       simstate.addYaw(Units.radiansToDegrees(VectorUtils.angleDifference(simyawrad,lastSimYawRad)));
     }
     double yaw = (pidgey.getYaw().getValueAsDouble() % 360 + 360) % 360;
-    // we're not using pitch and roll, don't bother requesting them over the CAN bus.
-    // double pitch = (pidgey.getPitch().getValue();
-    // double roll = (pidgey.getRoll().getValue(); 
-    double pitch = 0;
-    double roll = 0;
+    double pitch = pidgey.getPitch().getValueAsDouble();
+    double roll = pidgey.getRoll().getValueAsDouble(); 
 
     return new double[]{yaw, pitch, roll};
   }
@@ -154,8 +159,26 @@ public class Gyro extends SubsystemBase {
     return ypr[2];
   }
 
+  /**
+   * Returns the direction that the robot is tipping.
+   * The returned angle is relative to the robot
+   * @return angle from forward in radians
+   */
+  public double getTippingAngle(){
+    double gvx = pidgey.getGravityVectorX().getValueAsDouble();
+    double gvy = pidgey.getGravityVectorY().getValueAsDouble();
+    if (gvx <= 1e-6 && gvy <= 1e-6){
+      return 0;
+    }
+    return new Translation2d(gvx,gvy).getAngle().getRadians();
+  }
+
   public void resetPrimarySensor() {
     pidgey.reset();
+  }
+
+  public boolean isTipping(){
+    return m_isTipped.get();
   }
 
   public void setGyroInit(double _y, double _p, double _r){

--- a/2025-ReefScape/src/main/java/frc/utils/Action.java
+++ b/2025-ReefScape/src/main/java/frc/utils/Action.java
@@ -3,6 +3,7 @@ package frc.utils;
 public class Action {
     public boolean m_state;
     
+    public boolean m_enable = true;
     public Runnable onTrue;
     public Runnable onFalse;
     public Runnable onChange;
@@ -13,6 +14,16 @@ public class Action {
 
     public Action(boolean init){
         m_state = init;
+    }
+
+    public Action disable(){
+        m_enable = false;
+        return this;
+    }
+
+    public Action enable(){
+        m_enable = true;
+        return this;
     }
 
     public Action onTrue(Runnable action){
@@ -32,13 +43,13 @@ public class Action {
 
     public void calculate(boolean val){
         if (m_state != val){
-            if (onChange != null){
+            if (m_enable && onChange != null){
                 onChange.run();
             }
-            if (val && onTrue != null){
+            if (m_enable && val && onTrue != null){
                 onTrue.run();
             }
-            if (!val && onFalse != null){
+            if (m_enable && !val && onFalse != null){
                 onFalse.run();
             }
             m_state = val;

--- a/2025-ReefScape/src/main/java/frc/utils/Hysteresis.java
+++ b/2025-ReefScape/src/main/java/frc/utils/Hysteresis.java
@@ -28,6 +28,12 @@ public class Hysteresis {
     public void set(boolean state){
         m_state = state;
     }
+
+    /**
+     * Specifies the amount the value needs to increase or decrease above the threshold in order to change the state.
+     * @param hysteresis
+     * @return
+     */
     public Hysteresis withHysteresis(double hysteresis){
         m_hysteresis = hysteresis;
         return this;
@@ -44,5 +50,7 @@ public class Hysteresis {
         m_onFalse = action;
         return this;
     }
-
+    public Boolean get(){
+        return m_state;
+    }
 }


### PR DESCRIPTION
Add functionality to lower the elevator, bring the arm in and align the swerve pods in the direction of the tip to get off an algae, if the bot is tipping more than 15 degrees. 

Tested on Robot 3/26. Didn't let it drive up on algae. Bot reversed direction before beaching and drove off of one successfully!!!